### PR TITLE
New feature that renders the spinner component based on it parent element

### DIFF
--- a/examples-src/App.vue
+++ b/examples-src/App.vue
@@ -137,6 +137,88 @@
         </div>
 
         <div :class="header_cls">
+          <div class="pb2 f3">Fit to Parent Element</div>
+          <div class="f6">Spinners can also only be rendered inside it's parent elements. Very usefull when using ajax requests (the parent must have the position: relative).</div>
+        </div>
+        <div :class="box_cls" :style="box_style">
+          <div :class="label_cls">Rendered inside a Form</div>
+          <form style="position: relative; width: 90%; margin: auto">
+            <spinner :inside-parent="true"></spinner>
+            <h4>A Form</h4>
+            <ul>
+              <li>
+                <label>Label 1</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 2</label>
+                <input type="text" />
+              </li>
+              <br><br>
+              <li>
+                <label>Label 3</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 4</label>
+                <input type="text" />
+              </li>
+              <br><br>
+              <li>
+                <label>Label 5</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 6</label>
+                <input type="text" />
+              </li>
+            </ul>
+            <button>Submit</button>
+          </form>
+        </div>
+        <div :class="box_cls" :style="box_style">
+          <br>
+          <div :class="label_cls">Rendered in part of a Form</div>
+          <form style="position: relative; width: 90%; margin: auto">
+            <h4>A Form</h4>
+            <ul>
+              <div style="position: relative">
+                <spinner :inside-parent="true"></spinner>
+                <li>
+                  <label>Label 1</label>
+                  <input type="text" />
+                </li>
+                <li>
+                  <label>Label 2</label>
+                  <input type="text" />
+                </li>
+                <br><br>
+                <li>
+                  <label>Label 3</label>
+                  <input type="text" />
+                </li>
+                <li>
+                  <label>Label 4</label>
+                  <input type="text" />
+                </li>
+                <br><br>
+                <button>Request Data</button>
+              </div>
+              <br>
+              <li>
+                <label>Label 5</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 6</label>
+                <input type="text" />
+              </li>
+            </ul>
+            <button>Submit</button>
+          </form>
+        </div>
+
+        <div :class="header_cls">
           <div class="pb2 f3">Full Power of Vue.js</div>
           <div class="f6">With the power of the Vue.js virtual DOM, properties can be updated without needing to re-render the entire component.</div>
         </div>
@@ -187,6 +269,10 @@
                   <tr>
                     <td :class="cell_cls">Text Foreground Color:</td>
                     <td :class="cell_cls">{{spinner_text_fg_color}}</td>
+                  </tr>
+                  <tr>
+                    <td :class="cell_cls">Inside Parent:</td>
+                    <td :class="cell_cls">false</td>
                   </tr>
                 </tbody>
               </table>
@@ -319,5 +405,17 @@
 
   .css-box + .css-box {
     border-top: 1px solid rgba(0,0,0,0.1)
+  }
+
+  ul {
+    width: 100%;
+  }
+  ul li {
+    width: 49%;
+    display: inline-block;
+  }
+
+  ul li > * {
+    width: 100%;
   }
 </style>

--- a/examples-src/App.vue
+++ b/examples-src/App.vue
@@ -182,27 +182,32 @@
           <form style="position: relative; width: 90%; margin: auto">
             <h4>A Form</h4>
             <ul>
+              <li>
+                <label>Label 1</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 2</label>
+                <input type="text" />
+              </li>
+              <br><br>
+              <li>
+                <label>Label 3</label>
+                <input type="text" />
+              </li>
+              <li>
+                <label>Label 4</label>
+                <input type="text" />
+              </li>
+              <br><br>
+              <h5>Generate Random Text</h5>
               <div style="position: relative">
-                <spinner :inside-parent="true"></spinner>
-                <li>
-                  <label>Label 1</label>
-                  <input type="text" />
-                </li>
-                <li>
-                  <label>Label 2</label>
-                  <input type="text" />
-                </li>
-                <br><br>
-                <li>
-                  <label>Label 3</label>
-                  <input type="text" />
-                </li>
-                <li>
-                  <label>Label 4</label>
-                  <input type="text" />
-                </li>
-                <br><br>
-                <button>Request Data</button>
+                <spinner :inside-parent="true" v-show="show_spinner"></spinner>
+                
+                <div style="border: 1px solid rgba(0, 0, 0, 0.1); width:100%; height: 250px" v-html="custom_paragraphs"></div>
+                
+                <br>
+                <button type="button" @click="fillCustomParagraphs()">Request Data</button>
               </div>
               <br>
               <li>
@@ -214,7 +219,7 @@
                 <input type="text" />
               </li>
             </ul>
-            <button>Submit</button>
+            <button disabled>Submit</button>
           </form>
         </div>
 
@@ -321,7 +326,9 @@
         spinner_spacing: 4,
         spinner_message: "I'll start changing in 4 seconds",
         spinner_text_fg_color: undefined,
-        spinner_font_size: 13
+        spinner_font_size: 13,
+        custom_paragraphs: '',
+        show_spinner: false
       }
     },
     computed: {
@@ -342,6 +349,22 @@
       },
       cell_cls() {
         return 'ph1 pv1 ba b--moon-gray'
+      }
+    },
+    methods: {
+      fillCustomParagraphs() {
+        // http://loripsum.net/api
+        // http://thecatapi.com/api/images/get?format=xml&results_per_page=20
+        this.show_spinner = true
+        this.customParagraphs = this.$http.get('https://baconipsum.com/api/?type=all-meat&paras=1&start-with-lorem=1&format=html')
+        .then(({bodyText}) => {
+          this.show_spinner = false
+          this.custom_paragraphs = bodyText
+        })
+        .catch(error => {
+          this.show_spinner = false
+          console.log(error)
+        })
       }
     },
     mounted() {

--- a/examples-src/index.js
+++ b/examples-src/index.js
@@ -1,5 +1,8 @@
 import Vue from 'vue'
+import VueResource from 'vue-resource'
 import App from './App.vue'
+
+Vue.use(VueResource)
 
 const app = new Vue({
   el: '#app',

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "sass-loader": "^6.0.3",
     "vue": "^2.2.6",
     "vue-loader": "^11.3.3",
+    "vue-resource": "^1.3.4",
     "vue-style-loader": "^3.0.0",
     "vue-template-compiler": "^2.2.6",
     "webpack": "^2.4.1",

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -16,7 +16,7 @@
       'size': {
         // either a number (pixel width/height) or 'tiny', 'small',
         // 'medium', 'large', 'huge', 'massive' for common sizes
-        default: 32 /* modificado */
+        default: 32
       },
       'line-size': {
         type: Number,
@@ -156,7 +156,7 @@
           'font-size': this.text_font_size+'px',
           'text-align': 'center'
         }
-      },
+      }
     }
   }
 </script>

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,6 +1,6 @@
 <template>
-  <div name="root-spinner">
-    <div class="vue-simple-spinner" :style="spinner_style" name="spinner"></div>
+  <div :style="root_style">
+    <div class="vue-simple-spinner" :style="spinner_style"></div>
     <div class="vue-simple-spinner" :style="text_style" v-if="message.length > 0">{{message}}</div>
   </div>
 </template>
@@ -114,7 +114,7 @@
 
         return isNumber(this.fontSize) ? this.fontSize : 13
       },
-      spinner_style() {
+      default_style() {
         return {
           'margin': '0 auto',
           'border-radius': '100%',
@@ -125,6 +125,30 @@
           'animation': 'vue-simple-spinner-spin '+this.speed+'s linear infinite'
         }
       },
+      inner_style() {
+        let innerStyle = this.default_style
+        innerStyle.position = 'absolute'
+        innerStyle.left = '0'
+        innerStyle.right = '0'
+        innerStyle.top = '0'
+        innerStyle.bottom = '0'
+        innerStyle.margin = 'auto !important'
+        return innerStyle
+      },
+      spinner_style() {
+        return this.insideParent == true ? this.inner_style : this.default_style
+      },
+      root_style() {
+        var innerRootStyle = {
+          'text-align': 'right',
+          'position': 'absolute',
+          'width': '100%',
+          'height': '100%',
+          'z-index': '5',
+          'background-color': 'rgba(220, 220, 220, 0.5)'
+        }
+        return this.insideParent == true ? innerRootStyle : {'text-align': 'right'}
+      },
       text_style() {
         return {
           'margin-top': this.text_margin_top+'px',
@@ -133,32 +157,6 @@
           'text-align': 'center'
         }
       },
-    },
-    watch: {
-      insideParent() {
-        this.toggleInsideParent(this.insideParent)
-      }
-    },
-    methods: {
-      toggleInsideParent(renderInsideParent) {
-        let spinnerElement = document.getElementsByName("spinner")[0]
-        let rootSpinnerElement = document.getElementsByName("root-spinner")[0]
-        let spinnerParent = rootSpinnerElement.parentNode
-        console.log(spinnerParent)
-        if(renderInsideParent) {
-          spinnerElement.classList.add('inner-spinner')
-          rootSpinnerElement.classList.add('root-spinner')
-          spinnerParent.classList.add('spinner-parent')
-        }
-        else {
-          spinnerElement.classList.remove('inner-spinner')
-          rootSpinnerElement.classList.remove('root-spinner')
-          spinnerParent.classList.remove('spinner-parent')
-        }
-      }
-    },
-    mounted() {
-      this.toggleInsideParent(this.insideParent)
     }
   }
 </script>
@@ -166,25 +164,6 @@
 <style>
   .vue-simple-spinner {
     transition: all 0.3s linear;
-  }
-
-  .inner-spinner {
-    position: absolute;
-    left:0; right:0;
-    top:0; bottom:0;
-    margin: auto !important;
-  }
-
-  .root-spinner {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    z-index: 5;
-    background-color: rgba(220, 220, 220, 0.5);
-  }
-
-  .spinner-parent {
-    position: relative;
   }
 
   @keyframes vue-simple-spinner-spin {

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,6 +1,6 @@
 <template>
-  <div style="text-align: right">
-    <div class="vue-simple-spinner" :style="spinner_style"></div>
+  <div name="root-spinner">
+    <div class="vue-simple-spinner" :style="spinner_style" name="spinner"></div>
     <div class="vue-simple-spinner" :style="text_style" v-if="message.length > 0">{{message}}</div>
   </div>
 </template>
@@ -16,7 +16,7 @@
       'size': {
         // either a number (pixel width/height) or 'tiny', 'small',
         // 'medium', 'large', 'huge', 'massive' for common sizes
-        default: 32
+        default: 32 /* modificado */
       },
       'line-size': {
         type: Number,
@@ -49,6 +49,10 @@
       'text-fg-color': {
         type: String,
         default: '#555'
+      },
+      'inside-parent': {
+        type: Boolean,
+        default: false
       }
     },
     computed: {
@@ -128,7 +132,33 @@
           'font-size': this.text_font_size+'px',
           'text-align': 'center'
         }
+      },
+    },
+    watch: {
+      insideParent() {
+        this.toggleInsideParent(this.insideParent)
       }
+    },
+    methods: {
+      toggleInsideParent(renderInsideParent) {
+        let spinnerElement = document.getElementsByName("spinner")[0]
+        let rootSpinnerElement = document.getElementsByName("root-spinner")[0]
+        let spinnerParent = rootSpinnerElement.parentNode
+        console.log(spinnerParent)
+        if(renderInsideParent) {
+          spinnerElement.classList.add('inner-spinner')
+          rootSpinnerElement.classList.add('root-spinner')
+          spinnerParent.classList.add('spinner-parent')
+        }
+        else {
+          spinnerElement.classList.remove('inner-spinner')
+          rootSpinnerElement.classList.remove('root-spinner')
+          spinnerParent.classList.remove('spinner-parent')
+        }
+      }
+    },
+    mounted() {
+      this.toggleInsideParent(this.insideParent)
     }
   }
 </script>
@@ -136,6 +166,25 @@
 <style>
   .vue-simple-spinner {
     transition: all 0.3s linear;
+  }
+
+  .inner-spinner {
+    position: absolute;
+    left:0; right:0;
+    top:0; bottom:0;
+    margin: auto !important;
+  }
+
+  .root-spinner {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 5;
+    background-color: rgba(220, 220, 220, 0.5);
+  }
+
+  .spinner-parent {
+    position: relative;
   }
 
   @keyframes vue-simple-spinner-spin {


### PR DESCRIPTION
A functionality that show the spinner component just inside it's parent element. It's good to use it with ajax requests, when the user have to wait for the response.
This feature does not block the whole page or form, just the components and it parent that makes the request.

**Configuration**
The configuration it's pretty simple, just:
- pass the `:inside-parent` prop to the spinner component, that receives a boolean
- add/change the `position: relative` css attribute to the parent element or component of the spinner

A example of how it works it's already implemented in the examples page of this pull request.